### PR TITLE
Make parameter names consistent with Generations + JumpBoard template

### DIFF
--- a/HedgeEdit/DebugStartup/Templates/Colors/Common/DashPanel.xml
+++ b/HedgeEdit/DebugStartup/Templates/Colors/Common/DashPanel.xml
@@ -2,7 +2,7 @@
 <Template>
   <OutOfControl type="float" default="0.5" description="How long the game locks your control for after coming in contact with this object." />
   <Speed type="float" default="0" description="How much speed the DashPanel will send you off with." />
-  <IsVisible type="bool" default="true" description="Whether the DashPanel displays it's model, or is invisible (used in stages like Starlight Carnival)." />
+  <IsVisibleModel type="bool" default="true" description="Whether the DashPanel displays it's model, or is invisible (used in stages like Starlight Carnival)." />
   <Unknown5 type="bool" default="false" description="Padding?" />
   <Unknown6 type="bool" default="false" description="Padding?" />
   <Unknown7 type="bool" default="false" description="Padding?" />

--- a/HedgeEdit/DebugStartup/Templates/Colors/Common/JumpBoard.xml
+++ b/HedgeEdit/DebugStartup/Templates/Colors/Common/JumpBoard.xml
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Template>
+  <ImpulseSpeedOnNormal type="float" default="500" description="Initial speed Sonic is sent off with." />
+  <ImpulseSpeedOnBoost type="float" default="500" description="Initial speed Sonic is sent off with while boosting." />
+  <OutOfControl type="float" default="2.5" description="How long the game locks your control for after coming in contact with this object, in seconds." />
+  <AngleType type="enum" default="2" description="Size of object; 0 for Small, 1 for Medium, 2 for Large. All have an angle of 30°, 15° variant does not exist in Colors unlike Generations and Unleashed." />
+</Template>

--- a/HedgeEdit/DebugStartup/Templates/Colors/Common/Ring.xml
+++ b/HedgeEdit/DebugStartup/Templates/Colors/Common/Ring.xml
@@ -3,7 +3,7 @@
   <ResetTime type="float" default="0" description="" />
   <Unknown4 type="uint" default="0" description="" />
   <IsReset type="bool" default="false" description="" />
-  <CanBeLightSpeedDashedUpon type="bool" default="true" description="" />
+  <IsLightSpeedDashTarget type="bool" default="true" description="" />
   <SetPlaceType type="enum" default="0" description="" />
   <Unknown5 type="enum" default="0" description="" />
   <Unknown6 type="uint" default="0" description="" />

--- a/HedgeEdit/DebugStartup/Templates/Colors/Common/Spring.xml
+++ b/HedgeEdit/DebugStartup/Templates/Colors/Common/Spring.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Template>
-  <Speed type="float" default="500" description="How much speed the spring will send you off with." />
+  <FirstSpeed type="float" default="500" description="How much speed the spring will send you off with." />
   <OutOfControl type="float" default="0.5" description="How long the game locks your control for after coming in contact with this object." />
   <KeepVelocityDistance type="float" default="50" description="How far away Sonic must travel after coming in contact with this object before he begins to loose speed." />
   <Unknown4 type="float" default="1" description="Spring Type? Seems to be 2 for springs that only appear when you have Super Sonic enabled. Odd that it's a float though." />
   <Unknown5 type="bool" default="false" description="" />
   <Unknown6 type="bool" default="false" description="" />
   <Unknown7 type="bool" default="false" description="" />
-  <IsTargeting type="bool" default="false" description="Whether or not the spring should attempt to send Sonic towards the target position." />
-  <TargetPosition type="position" description="The position the spring will attempt to send Sonic towards if IsTargeting is set to true." />
+  <m_IsMonkeyHunting type="bool" default="false" description="Whether or not the spring should attempt to send Sonic towards the target position." />
+  <m_MonkeyTarget type="position" description="The position the spring will attempt to send Sonic towards if IsTargeting is set to true." />
   <Unknown8 type="bool" default="true" description="" />
   <Unknown9 type="bool" default="false" description="" />
   <Unknown10 type="bool" default="true" description="" />


### PR DESCRIPTION
This will allow for easy loading of data from one game and saving to another, when such a feature is implemented.