### PR TITLE
MinGW support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,15 @@ if(MSVC)
     add_compile_options(/permissive- /utf-8)
 endif()
 
+# MinGW is finicky with unicode
+if(MINGW)
+    if(HEDGELIB_WIN32_FORCE_ANSI)
+        SET(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -static")
+    else()
+        SET(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -municode -static")
+    endif()
+endif()  
+
 # Make CMake check for packages in "Dependencies" subdirectory
 list(APPEND CMAKE_PREFIX_PATH
     ${HEDGELIB_LOCAL_DEPENDENCIES_DIR}

--- a/HedgeLib/include/hedgelib/hl_memory.h
+++ b/HedgeLib/include/hedgelib/hl_memory.h
@@ -276,6 +276,8 @@ OutputIt move_strong(InputIt begin, InputIt end, OutputIt dst) noexcept(
 {
 #ifdef _MSC_VER
     return _aligned_malloc(size, __STDCPP_DEFAULT_NEW_ALIGNMENT__);
+#elif __MINGW32__
+    return _aligned_malloc(size, __STDCPP_DEFAULT_NEW_ALIGNMENT__);
 #else
     return std::malloc(size);
 #endif
@@ -295,6 +297,8 @@ OutputIt move_strong(InputIt begin, InputIt end, OutputIt dst) noexcept(
 [[nodiscard]] inline void* allocate(std::size_t size, std::size_t alignment, const std::nothrow_t) noexcept
 {
 #ifdef _MSC_VER
+    return _aligned_malloc(size, alignment);
+#elif __MINGW32__
     return _aligned_malloc(size, alignment);
 #else
     return std::aligned_alloc(alignment, size);
@@ -344,6 +348,8 @@ template<typename T>
 {
 #ifdef _MSC_VER
     return _aligned_realloc(ptr, size, __STDCPP_DEFAULT_NEW_ALIGNMENT__);
+#elif __MINGW32__
+    return _aligned_realloc(ptr, size, __STDCPP_DEFAULT_NEW_ALIGNMENT__);
 #else
     return std::realloc(ptr, size);
 #endif
@@ -364,6 +370,8 @@ template<typename T>
     std::size_t alignment, const std::nothrow_t) noexcept
 {
 #ifdef _MSC_VER
+    return _aligned_realloc(ptr, size, alignment);
+#elif __MINGW32__
     return _aligned_realloc(ptr, size, alignment);
 #else
     const auto mem = std::aligned_alloc(alignment, size);
@@ -427,6 +435,8 @@ template<typename T>
 inline void free(void* ptr) noexcept
 {
 #ifdef _MSC_VER
+    _aligned_free(ptr);
+#elif __MINGW32__
     _aligned_free(ptr);
 #else
     std::free(ptr);

--- a/HedgeLib/include/hedgelib/io/hl_bina.h
+++ b/HedgeLib/include/hedgelib/io/hl_bina.h
@@ -1011,14 +1011,14 @@ HL_API endian_flag fix_container32(void* rawData, std::size_t dataSize);
 
 inline endian_flag fix_container32(blob& rawData)
 {
-    fix_container32(rawData.data(), rawData.size());
+    return fix_container32(rawData.data(), rawData.size());
 }
 
 HL_API endian_flag fix_container64(void* rawData, std::size_t dataSize);
 
 inline endian_flag fix_container64(blob& rawData)
 {
-    fix_container64(rawData.data(), rawData.size());
+    return fix_container64(rawData.data(), rawData.size());
 }
 
 template<typename T = void>

--- a/HedgeLib/src/hl_scene.cpp
+++ b/HedgeLib/src/hl_scene.cpp
@@ -481,12 +481,12 @@ public:
         return true;
     }
 
-    size_t Write(const void* pData, FbxUInt64 pSize) override
+    int Write(const void* pData, int pSize) override
     {
         return (!isOpen) ? 0 : static_cast<int>(m_stream->write(pSize, pData));
     }
 
-    size_t Read(void* pData, FbxUInt64 pSize) const override
+    int Read(void* pData, int pSize) const override
     {
         return (!isOpen) ? 0 : static_cast<int>(m_stream->read(pSize, pData));
     }
@@ -508,12 +508,12 @@ public:
         m_stream->seek(in_fbx_get_seek_mode(pSeekPos), pOffset);
     }
 
-    FbxInt64 GetPosition() const override
+    long GetPosition() const override
     {
         return (isOpen) ? m_stream->tell() : 0;
     }
 
-    void SetPosition(FbxInt64 pPosition) override
+    void SetPosition(long pPosition) override
     {
         if (isOpen)
         {

--- a/HedgeLib/src/sets/hl_hson.cpp
+++ b/HedgeLib/src/sets/hl_hson.cpp
@@ -1103,7 +1103,7 @@ static const parameter* in_get_parameter(
             const auto nextNameSep = std::strchr(curNameSep + 1, '/');
             if (nextNameSep)
             {
-                curName.assign(curNameSep + 1, nextNameSep);
+                curName.assign(curNameSep + 1, nextNameSep[0]);
             }
             else
             {

--- a/HedgeTools/HedgeArcPack/src/main.cpp
+++ b/HedgeTools/HedgeArcPack/src/main.cpp
@@ -425,7 +425,11 @@ static void print_usage(std::FILE* stream)
     hl::console::write(get_text(text_id::help1), stream);
 
     // Print types.
+#if defined(__MINGW32__) && !defined(HL_WIN32_FORCE_ANSI)
+    print_types(HL_NTEXT("\t\t%ls"), stream);
+#else
     print_types(HL_NTEXT("\t\t%s"), stream);
+#endif
 
     // Print help2.
     hl::console::write(get_text(text_id::help2), stream);
@@ -455,7 +459,13 @@ static arc_type prompt_for_arc_type()
 {
     // Ask user for type and print all valid type options.
     hl::console::write(get_text(text_id::type1), stderr);
+    
+#if defined(__MINGW32__) && !defined(HL_WIN32_FORCE_ANSI)
+    print_types(HL_NTEXT(" %ls"), stderr);
+#else
     print_types(HL_NTEXT(" %s"), stderr);
+#endif
+
     hl::console::write(get_text(text_id::type2), stderr);
 
     // Get type from user input and return it.

--- a/HedgeTools/HedgeSet/src/main.cpp
+++ b/HedgeTools/HedgeSet/src/main.cpp
@@ -104,12 +104,23 @@ static void print_usage(const hl::nchar* templateDir, std::FILE* s)
     hl::nfputs(HL_NTEXT(" -game=VALUE     Specifies which template to use for conversion.\n"), s);
     hl::nfputs(HL_NTEXT("                 Valid options are:\n\n"), s);
 
+#if defined(__MINGW32__) && !defined(HL_WIN32_FORCE_ANSI)
+    print_valid_game_types(templateDir, HL_NTEXT("                 %ls"), s);
+#else
     print_valid_game_types(templateDir, HL_NTEXT("                 %s"), s);
+#endif
+    
     hl::nfputs(HL_NTEXT("\n"), s);
 
     hl::nfputs(HL_NTEXT(" -platform=VALUE Specifies which platform to use for conversion.\n"), s);
     hl::nfputs(HL_NTEXT("                 Valid options are:\n\n"), s);
+    
+#if defined(__MINGW32__) && !defined(HL_WIN32_FORCE_ANSI)
+    print_valid_platform_types(HL_NTEXT("                 %ls"), s);
+#else
     print_valid_platform_types(HL_NTEXT("                 %s"), s);
+#endif
+
 }
 
 static hl::nstring prompt_for_game_type(const hl::nchar* templateDir)
@@ -118,7 +129,11 @@ static hl::nstring prompt_for_game_type(const hl::nchar* templateDir)
     hl::nfputs(HL_NTEXT("Game type could not be auto-determined.\n"
         "Please enter one of the following options:\n\n"), stderr);
 
+#if defined(__MINGW32__) && !defined(HL_WIN32_FORCE_ANSI)
+    print_valid_game_types(templateDir, HL_NTEXT(" %ls"), stderr);
+#else
     print_valid_game_types(templateDir, HL_NTEXT(" %s"), stderr);
+#endif
     
     hl::nfprintf(stderr, HL_NTEXT("Game type: "));
 
@@ -132,7 +147,11 @@ static platform_type prompt_for_platform_type()
     hl::nfputs(HL_NTEXT("Platform type could not be auto-determined.\n"
         "Please enter one of the following options:\n\n"), stderr);
 
+#if defined(__MINGW32__) && !defined(HL_WIN32_FORCE_ANSI)
+    print_valid_platform_types(HL_NTEXT(" %ls"), stderr);
+#else
     print_valid_platform_types(HL_NTEXT(" %s"), stderr);
+#endif
     
     hl::nfprintf(stderr, HL_NTEXT("Platform type: "));
 
@@ -145,7 +164,12 @@ static void convert_gedit_v3_to_hson(const hl::set_object_type_database& objType
     const hl::nchar* input, const hl::nchar* output, platform_type platform)
 {
     // Load .gedit file.
+#if defined(__MINGW32__) && !defined(HL_WIN32_FORCE_ANSI)
+    hl::nprintf(HL_NTEXT("Loading set data from \"%ls\"...\n"), input);
+#else
     hl::nprintf(HL_NTEXT("Loading set data from \"%s\"...\n"), input);
+#endif
+
     hl::blob blob(input);
 
     // Fix BINA data.
@@ -182,7 +206,12 @@ static void convert_hson_to_gedit_v3(const hl::set_object_type_database& objType
     const hl::nchar* input, const hl::nchar* output, platform_type platform)
 {
     // Load HSON data.
+#if defined(__MINGW32__) && !defined(HL_WIN32_FORCE_ANSI)
+    hl::nprintf(HL_NTEXT("Loading HSON data from \"%ls\"...\n"), input);
+#else
     hl::nprintf(HL_NTEXT("Loading HSON data from \"%s\"...\n"), input);
+#endif
+
     hl::hson::project hsonProject(input);
 
     // Save gedit data to file.
@@ -243,7 +272,11 @@ int HL_NMAIN(int argc, hl::nchar* argv[])
         {
             hl::nfprintf(stderr,
                 HL_NTEXT("ERROR: The templates directory was "
+#if defined(__MINGW32__) && !defined(HL_WIN32_FORCE_ANSI)
+                "not found at the expected path (\"%ls\")."),
+#else
                 "not found at the expected path (\"%s\")."),
+#endif
                 templateDir);
 
             hl::console::pause_if_necessary(current_language);
@@ -314,7 +347,12 @@ int HL_NMAIN(int argc, hl::nchar* argv[])
         }
 
         // Load templates for the given game.
+#if defined(__MINGW32__) && !defined(HL_WIN32_FORCE_ANSI)
+        hl::nprintf(HL_NTEXT("Loading templates for %ls...\n"), game);
+#else
         hl::nprintf(HL_NTEXT("Loading templates for %s...\n"), game);
+#endif
+        
         const hl::set_object_type_database objTypeDB(
             hl::path::combine(templateDir, game) +
             HL_NTEXT(".json"));
@@ -341,7 +379,11 @@ int HL_NMAIN(int argc, hl::nchar* argv[])
             {
                 hl::nfprintf(stderr, HL_NTEXT(
                     "WARNING: Input file type is of an unknown extension. "
+#if defined(__MINGW32__) && !defined(HL_WIN32_FORCE_ANSI)
+                    "Proceeding as if input file is a %ls file.\n"), gameExt);
+#else
                     "Proceeding as if input file is a %s file.\n"), gameExt);
+#endif
             }
 
             if (!output)

--- a/cmake/modules/FindFbx.cmake
+++ b/cmake/modules/FindFbx.cmake
@@ -86,7 +86,12 @@ function(FindFbxLibrariesGeneric _FBX_ROOT_DIR _OUT_FBX_LIBRARIES _OUT_FBX_LIBRA
   elseif(APPLE)
     set(FBX_CP_PATH "*")
   else()
-    set(FBX_CP_PATH "*")
+    if(MINGW)
+        # Idk, installed 2020.2.1 vs2019
+        set(FBX_CP_PATH "vs2019")
+    else()
+        set(FBX_CP_PATH "*")
+    endif()
   endif()
 
   # Detects current processor type.

--- a/cmake/modules/FindLZ4.cmake
+++ b/cmake/modules/FindLZ4.cmake
@@ -30,9 +30,16 @@ find_path(LZ4_INCLUDE_DIR
   NAMES lz4.h
   DOC "lz4 include directory")
 mark_as_advanced(LZ4_INCLUDE_DIR)
+# MinGW additions. Under Msys2 we can just specify the static LZ4 library directly
+if(MINGW)
+find_library(LZ4_LIBRARY
+  NAMES liblz4.a liblz4
+  DOC "lz4 library")
+else()
 find_library(LZ4_LIBRARY
   NAMES lz4 liblz4
   DOC "lz4 library")
+endif()
 mark_as_advanced(LZ4_LIBRARY)
 
 if (LZ4_INCLUDE_DIR)


### PR DESCRIPTION
- Added return statements where there were none (`hl_bina.h`)
- We can directly specify the required static library in FindLZ4.cmake
- Overrides in `hl_scene.cpp` changed because it couldn't compile due to differences in declarations in `fbxstream.h`
- HedgeTools need to specify `"%ls"` for strings if unicode is requested
- HedgeRender was only tested with 2020.2.1 vs2019
- HedgeRender requires `FBX_SHARED=True`

To build in Msys2 MINGW64 shell:
```
$ pacman -S cmake git gcc mingw-w64-x86_64-robin-hood-hashing mingw-w64-x86_64-glm mingw-w64-x86_64-lz4 mingw-w64-x86_64-zlib mingw-w64-x86_64-glfw mingw-w64-x86_64-rapidjson
$ mkdir build && cd build
$ cmake .. -DFBX_SHARED=True
$ ninja
```
