### PR TITLE
Remove incorrect fixed size array usage from colors template files

### DIFF
--- a/Templates/colors.json
+++ b/Templates/colors.json
@@ -1970,13 +1970,34 @@
     "BossCoffeeCupSpawner": {
       "parent": "BossFerrisWheelBaseSpawner",
       "fields": [
-        { "name": "AttackTime", "type": "array", "subtype": "float32", "size": 3 }
+        { "name": "AttackTime[0]", "type": "float32" },
+        { "name": "AttackTime[1]", "type": "float32" },
+        { "name": "AttackTime[2]", "type": "float32" }
       ]
     },
     "ObjCoffeeCupSpawner": {
       "parent": "ObjGondolaBaseSpawner",
       "fields": [
-        { "name": "PixieType", "type": "array", "subtype": "ObjCoffeeCupSpawner::PixieType", "size": 20 }
+        { "name": "PixieType[0]", "type": "ObjCoffeeCupSpawner::PixieType" },
+        { "name": "PixieType[1]", "type": "ObjCoffeeCupSpawner::PixieType" },
+        { "name": "PixieType[2]", "type": "ObjCoffeeCupSpawner::PixieType" },
+        { "name": "PixieType[3]", "type": "ObjCoffeeCupSpawner::PixieType" },
+        { "name": "PixieType[4]", "type": "ObjCoffeeCupSpawner::PixieType" },
+        { "name": "PixieType[5]", "type": "ObjCoffeeCupSpawner::PixieType" },
+        { "name": "PixieType[6]", "type": "ObjCoffeeCupSpawner::PixieType" },
+        { "name": "PixieType[7]", "type": "ObjCoffeeCupSpawner::PixieType" },
+        { "name": "PixieType[8]", "type": "ObjCoffeeCupSpawner::PixieType" },
+        { "name": "PixieType[9]", "type": "ObjCoffeeCupSpawner::PixieType" },
+        { "name": "PixieType[10]", "type": "ObjCoffeeCupSpawner::PixieType" },
+        { "name": "PixieType[11]", "type": "ObjCoffeeCupSpawner::PixieType" },
+        { "name": "PixieType[12]", "type": "ObjCoffeeCupSpawner::PixieType" },
+        { "name": "PixieType[13]", "type": "ObjCoffeeCupSpawner::PixieType" },
+        { "name": "PixieType[14]", "type": "ObjCoffeeCupSpawner::PixieType" },
+        { "name": "PixieType[15]", "type": "ObjCoffeeCupSpawner::PixieType" },
+        { "name": "PixieType[16]", "type": "ObjCoffeeCupSpawner::PixieType" },
+        { "name": "PixieType[17]", "type": "ObjCoffeeCupSpawner::PixieType" },
+        { "name": "PixieType[18]", "type": "ObjCoffeeCupSpawner::PixieType" },
+        { "name": "PixieType[19]", "type": "ObjCoffeeCupSpawner::PixieType" }
       ]
     },
     "ObjGondolaBaseSpawner": {
@@ -1991,7 +2012,26 @@
     "ObjGondolaSpawner": {
       "parent": "ObjGondolaBaseSpawner",
       "fields": [
-        { "name": "PixieType", "type": "array", "subtype": "ObjGondolaSpawner::PixieType", "size": 20 }
+        { "name": "PixieType[0]", "type": "ObjGondolaSpawner::PixieType" },
+        { "name": "PixieType[1]", "type": "ObjGondolaSpawner::PixieType" },
+        { "name": "PixieType[2]", "type": "ObjGondolaSpawner::PixieType" },
+        { "name": "PixieType[3]", "type": "ObjGondolaSpawner::PixieType" },
+        { "name": "PixieType[4]", "type": "ObjGondolaSpawner::PixieType" },
+        { "name": "PixieType[5]", "type": "ObjGondolaSpawner::PixieType" },
+        { "name": "PixieType[6]", "type": "ObjGondolaSpawner::PixieType" },
+        { "name": "PixieType[7]", "type": "ObjGondolaSpawner::PixieType" },
+        { "name": "PixieType[8]", "type": "ObjGondolaSpawner::PixieType" },
+        { "name": "PixieType[9]", "type": "ObjGondolaSpawner::PixieType" },
+        { "name": "PixieType[10]", "type": "ObjGondolaSpawner::PixieType" },
+        { "name": "PixieType[11]", "type": "ObjGondolaSpawner::PixieType" },
+        { "name": "PixieType[12]", "type": "ObjGondolaSpawner::PixieType" },
+        { "name": "PixieType[13]", "type": "ObjGondolaSpawner::PixieType" },
+        { "name": "PixieType[14]", "type": "ObjGondolaSpawner::PixieType" },
+        { "name": "PixieType[15]", "type": "ObjGondolaSpawner::PixieType" },
+        { "name": "PixieType[16]", "type": "ObjGondolaSpawner::PixieType" },
+        { "name": "PixieType[17]", "type": "ObjGondolaSpawner::PixieType" },
+        { "name": "PixieType[18]", "type": "ObjGondolaSpawner::PixieType" },
+        { "name": "PixieType[19]", "type": "ObjGondolaSpawner::PixieType" }
       ]
     },
     "ObjPirateCannonSpawner": {
@@ -2296,15 +2336,26 @@
       "parent": "EnemyMotoraBaseSpawner",
       "fields": [
         { "name": "NumMaxUnits", "type": "uint32" },
-        { "name": "LevelProbabilities", "type": "array", "subtype": "float32", "size": 6 },
+        { "name": "LevelProbabilities[0]", "type": "float32" },
+        { "name": "LevelProbabilities[1]", "type": "float32" },
+        { "name": "LevelProbabilities[2]", "type": "float32" },
+        { "name": "LevelProbabilities[3]", "type": "float32" },
+        { "name": "LevelProbabilities[4]", "type": "float32" },
+        { "name": "LevelProbabilities[6]", "type": "float32" },
         { "name": "XXProbability", "type": "float32" }
       ]
     },
     "EnemyMotoraEventSpawner": {
       "parent": "EnemyMotoraBaseSpawner",
       "fields": [
-        { "name": "PathIDs", "type": "array", "subtype": "uint32", "size": 4 },
-        { "name": "PathOffsets", "type": "array", "subtype": "float32", "size": 4}
+        { "name": "PathIDs[0]", "type": "uint32" },
+        { "name": "PathIDs[1]", "type": "uint32" },
+        { "name": "PathIDs[2]", "type": "uint32" },
+        { "name": "PathIDs[3]", "type": "uint32" },
+        { "name": "PathOffsets[0]", "type": "float32" },
+        { "name": "PathOffsets[1]", "type": "float32" },
+        { "name": "PathOffsets[2]", "type": "float32" },
+        { "name": "PathOffsets[3]", "type": "float32" }
       ]
     },
     "EnemyLanderSpawner": {
@@ -2822,7 +2873,11 @@
     },
     "ObjSlotSpawner": {
       "fields": [
-        { "name": "Probabilities", "type": "array", "subtype": "float32", "size": 5 }
+        { "name": "Probabilities[0]", "type": "float32" },
+        { "name": "Probabilities[1]", "type": "float32" },
+        { "name": "Probabilities[2]", "type": "float32" },
+        { "name": "Probabilities[3]", "type": "float32" },
+        { "name": "Probabilities[4]", "type": "float32" }
       ]
     },
     "ObjSprialDoorSpawner": {

--- a/Templates/scu.json
+++ b/Templates/scu.json
@@ -1970,13 +1970,34 @@
     "BossCoffeeCupSpawner": {
       "parent": "BossFerrisWheelBaseSpawner",
       "fields": [
-        { "name": "AttackTime", "type": "array", "subtype": "float32", "size": 3 }
+        { "name": "AttackTime[0]", "type": "float32" },
+        { "name": "AttackTime[1]", "type": "float32" },
+        { "name": "AttackTime[2]", "type": "float32" }
       ]
     },
     "ObjCoffeeCupSpawner": {
       "parent": "ObjGondolaBaseSpawner",
       "fields": [
-        { "name": "PixieType", "type": "array", "subtype": "ObjCoffeeCupSpawner::PixieType", "size": 20 }
+        { "name": "PixieType[0]", "type": "ObjCoffeeCupSpawner::PixieType" },
+        { "name": "PixieType[1]", "type": "ObjCoffeeCupSpawner::PixieType" },
+        { "name": "PixieType[2]", "type": "ObjCoffeeCupSpawner::PixieType" },
+        { "name": "PixieType[3]", "type": "ObjCoffeeCupSpawner::PixieType" },
+        { "name": "PixieType[4]", "type": "ObjCoffeeCupSpawner::PixieType" },
+        { "name": "PixieType[5]", "type": "ObjCoffeeCupSpawner::PixieType" },
+        { "name": "PixieType[6]", "type": "ObjCoffeeCupSpawner::PixieType" },
+        { "name": "PixieType[7]", "type": "ObjCoffeeCupSpawner::PixieType" },
+        { "name": "PixieType[8]", "type": "ObjCoffeeCupSpawner::PixieType" },
+        { "name": "PixieType[9]", "type": "ObjCoffeeCupSpawner::PixieType" },
+        { "name": "PixieType[10]", "type": "ObjCoffeeCupSpawner::PixieType" },
+        { "name": "PixieType[11]", "type": "ObjCoffeeCupSpawner::PixieType" },
+        { "name": "PixieType[12]", "type": "ObjCoffeeCupSpawner::PixieType" },
+        { "name": "PixieType[13]", "type": "ObjCoffeeCupSpawner::PixieType" },
+        { "name": "PixieType[14]", "type": "ObjCoffeeCupSpawner::PixieType" },
+        { "name": "PixieType[15]", "type": "ObjCoffeeCupSpawner::PixieType" },
+        { "name": "PixieType[16]", "type": "ObjCoffeeCupSpawner::PixieType" },
+        { "name": "PixieType[17]", "type": "ObjCoffeeCupSpawner::PixieType" },
+        { "name": "PixieType[18]", "type": "ObjCoffeeCupSpawner::PixieType" },
+        { "name": "PixieType[19]", "type": "ObjCoffeeCupSpawner::PixieType" }
       ]
     },
     "ObjGondolaBaseSpawner": {
@@ -1991,7 +2012,26 @@
     "ObjGondolaSpawner": {
       "parent": "ObjGondolaBaseSpawner",
       "fields": [
-        { "name": "PixieType", "type": "array", "subtype": "ObjGondolaSpawner::PixieType", "size": 20 }
+        { "name": "PixieType[0]", "type": "ObjGondolaSpawner::PixieType" },
+        { "name": "PixieType[1]", "type": "ObjGondolaSpawner::PixieType" },
+        { "name": "PixieType[2]", "type": "ObjGondolaSpawner::PixieType" },
+        { "name": "PixieType[3]", "type": "ObjGondolaSpawner::PixieType" },
+        { "name": "PixieType[4]", "type": "ObjGondolaSpawner::PixieType" },
+        { "name": "PixieType[5]", "type": "ObjGondolaSpawner::PixieType" },
+        { "name": "PixieType[6]", "type": "ObjGondolaSpawner::PixieType" },
+        { "name": "PixieType[7]", "type": "ObjGondolaSpawner::PixieType" },
+        { "name": "PixieType[8]", "type": "ObjGondolaSpawner::PixieType" },
+        { "name": "PixieType[9]", "type": "ObjGondolaSpawner::PixieType" },
+        { "name": "PixieType[10]", "type": "ObjGondolaSpawner::PixieType" },
+        { "name": "PixieType[11]", "type": "ObjGondolaSpawner::PixieType" },
+        { "name": "PixieType[12]", "type": "ObjGondolaSpawner::PixieType" },
+        { "name": "PixieType[13]", "type": "ObjGondolaSpawner::PixieType" },
+        { "name": "PixieType[14]", "type": "ObjGondolaSpawner::PixieType" },
+        { "name": "PixieType[15]", "type": "ObjGondolaSpawner::PixieType" },
+        { "name": "PixieType[16]", "type": "ObjGondolaSpawner::PixieType" },
+        { "name": "PixieType[17]", "type": "ObjGondolaSpawner::PixieType" },
+        { "name": "PixieType[18]", "type": "ObjGondolaSpawner::PixieType" },
+        { "name": "PixieType[19]", "type": "ObjGondolaSpawner::PixieType" }
       ]
     },
     "ObjPirateCannonSpawner": {
@@ -2296,15 +2336,26 @@
       "parent": "EnemyMotoraBaseSpawner",
       "fields": [
         { "name": "NumMaxUnits", "type": "uint32" },
-        { "name": "LevelProbabilities", "type": "array", "subtype": "float32", "size": 6 },
+        { "name": "LevelProbabilities[0]", "type": "float32" },
+        { "name": "LevelProbabilities[1]", "type": "float32" },
+        { "name": "LevelProbabilities[2]", "type": "float32" },
+        { "name": "LevelProbabilities[3]", "type": "float32" },
+        { "name": "LevelProbabilities[4]", "type": "float32" },
+        { "name": "LevelProbabilities[6]", "type": "float32" },
         { "name": "XXProbability", "type": "float32" }
       ]
     },
     "EnemyMotoraEventSpawner": {
       "parent": "EnemyMotoraBaseSpawner",
       "fields": [
-        { "name": "PathIDs", "type": "array", "subtype": "uint32", "size": 4 },
-        { "name": "PathOffsets", "type": "array", "subtype": "float32", "size": 4}
+        { "name": "PathIDs[0]", "type": "uint32" },
+        { "name": "PathIDs[1]", "type": "uint32" },
+        { "name": "PathIDs[2]", "type": "uint32" },
+        { "name": "PathIDs[3]", "type": "uint32" },
+        { "name": "PathOffsets[0]", "type": "float32" },
+        { "name": "PathOffsets[1]", "type": "float32" },
+        { "name": "PathOffsets[2]", "type": "float32" },
+        { "name": "PathOffsets[3]", "type": "float32" }
       ]
     },
     "EnemyLanderSpawner": {
@@ -2840,7 +2891,11 @@
     },
     "ObjSlotSpawner": {
       "fields": [
-        { "name": "Probabilities", "type": "array", "subtype": "float32", "size": 5 }
+        { "name": "Probabilities[0]", "type": "float32" },
+        { "name": "Probabilities[1]", "type": "float32" },
+        { "name": "Probabilities[2]", "type": "float32" },
+        { "name": "Probabilities[3]", "type": "float32" },
+        { "name": "Probabilities[4]", "type": "float32" }
       ]
     },
     "ObjSprialDoorSpawner": {


### PR DESCRIPTION
The templates were previously set up incorrectly by myself to use the `size` parameter, as opposed to `array_size`. This has now been corrected by removing all fixed size array usage period because the parameter system in these games did not support fixed size array parameters until Sonic Forces.