### PR TITLE
Fix for erasing from hl::ordered_map

### DIFF
--- a/HedgeLib/include/hedgelib/hl_ordered_map.h
+++ b/HedgeLib/include/hedgelib/hl_ordered_map.h
@@ -317,26 +317,23 @@ public:
     iterator erase(const_iterator pos)
     {
         m_data.erase(pos->first);
-        const auto it = m_orderedPtrs.erase(pos.m_current);
-        return it;
+        return m_orderedPtrs.erase(pos.m_current);
     }
 
     iterator erase(iterator pos)
     {
         m_data.erase(pos->first);
-        const auto it = m_orderedPtrs.erase(pos.m_current);
-        return it;
+        return m_orderedPtrs.erase(pos.m_current);
     }
 
     iterator erase(const_iterator first, const_iterator last)
     {
-        for (; first != last; ++first)
+        for (auto it = first; first != last; ++it)
         {
-            m_data.erase((*first)->first);
+            m_data.erase((*it)->first);
         }
 
-        const auto it = m_orderedPtrs.erase(first.m_current, last.m_current);
-        return it;
+        return m_orderedPtrs.erase(first.m_current, last.m_current);;
     }
 
     void clear() noexcept

--- a/HedgeLib/include/hedgelib/hl_ordered_map.h
+++ b/HedgeLib/include/hedgelib/hl_ordered_map.h
@@ -316,26 +316,26 @@ public:
 
     iterator erase(const_iterator pos)
     {
-        const auto it = m_orderedPtrs.erase(pos.m_current);
         m_data.erase(pos->first);
+        const auto it = m_orderedPtrs.erase(pos.m_current);
         return it;
     }
 
     iterator erase(iterator pos)
     {
-        const auto it = m_orderedPtrs.erase(pos.m_current);
         m_data.erase(pos->first);
+        const auto it = m_orderedPtrs.erase(pos.m_current);
         return it;
     }
 
     iterator erase(const_iterator first, const_iterator last)
     {
-        const auto it = m_orderedPtrs.erase(first.m_current, last.m_current);
         for (; first != last; ++first)
         {
             m_data.erase((*first)->first);
         }
 
+        const auto it = m_orderedPtrs.erase(first.m_current, last.m_current);
         return it;
     }
 


### PR DESCRIPTION
Not completely sure this is the correct solution, but it works.
The problem was that previously, `m_orderedPtrs.erase(pos.m_current)` would invalidate the iterator, which was then followed with `m_data.erase(pos->first)`, leading to a crash.
This PR simply swaps these two, because `m_data.erase(pos->first)` doesn't invalidate the iterator.
If there's a better solution, I'm curious to hear, I needed this for a project so I made this quick fix.