### PR TITLE
Add CAB archive detection and fix SEGS deflate decompression with file association on windows.

### DIFF
--- a/HedgeLib/src/archives/hl_hh_archive.cpp
+++ b/HedgeLib/src/archives/hl_hh_archive.cpp
@@ -131,6 +131,15 @@ static void in_read(blob& hhArc, archive_entry_list* hlArc,
 void read(blob& hhArc, archive_entry_list* hlArc,
     std::vector<blob>* hhArcs)
 {
+    // Check for CAB Compression.
+    if (hhArc.size() >= 4)
+    {
+        u32 sig = *reinterpret_cast<const u32*>(hhArc.data());
+        if (sig == 0x4643534D)
+        {
+            throw std::runtime_error("CAB-compressed archives are not supported yet");
+        }
+    }
     // Check for Xbox Compression.
     if (x_check_signature(hhArc.size(), hhArc.data()))
     {

--- a/HedgeLib/src/hl_compression.cpp
+++ b/HedgeLib/src/hl_compression.cpp
@@ -370,8 +370,9 @@ void deflate_decompress_no_alloc(std::size_t srcSize,
 
     // Decompress deflate data.
     // TODO: Should we use Z_SYNC_FLUSH?
-    r = inflate(&stream, Z_SYNC_FLUSH);
-    if (r < Z_OK)
+    r = inflate(&stream, Z_FINISH);
+    inflateEnd(&stream);
+    if (r != Z_STREAM_END)
     {
         throw std::runtime_error("Failed to decompress deflate data");
     }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **IMPORTANT:** All code committed to this repository, preferably, should follow [these style guidelines](https://github.com/Radfordhound/HedgeLib/wiki/Code-Style).
 
-## Download.
+## Download
 
 This repository uses [AppVeyor](https://www.appveyor.com) to automatically build every commit!
 As such, you don't have to manually build any of the tools/libraries in this repository if you simply want to try out the latest versions.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **IMPORTANT:** All code committed to this repository, preferably, should follow [these style guidelines](https://github.com/Radfordhound/HedgeLib/wiki/Code-Style).
 
-## Download
+## Download.
 
 This repository uses [AppVeyor](https://www.appveyor.com) to automatically build every commit!
 As such, you don't have to manually build any of the tools/libraries in this repository if you simply want to try out the latest versions.


### PR DESCRIPTION
CAB-compressed archives were causing HedgeArcPack to run in the background and consume increasing amounts of RAM until system memory was exhausted, this occurred because the entire archive was loaded into memory before,checking the compression type. Now checks for CAB signature before loading the file, preventing memory consumption and immediately throwing an error that CAB archives are not supported.